### PR TITLE
Resume editing a route after finishing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add an `editExisting` method to modify previously drawn routes
+
 ## 0.1.7
 
 - Add a `setConfig` method

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add an `editExisting` method to modify previously drawn routes
+- The output now includes a `waypoints` property, used for `editExisting`
 
 ## 0.1.7
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -155,18 +155,26 @@
             });
             if (features.length > 0) {
               // If multiple routes overlap, arbitrarily edit one of them
-              let edit = features[0];
+              let editUid = features[0].properties.uid;
 
               // First remove the route from the completed set, so we don't
               // have duplicates. Be careful with the comparison;
               // queryRenderedFeatures doesn't have back a regular GeoJSON
-              // feature.
+              // feature. We need to retrieve the full feature for this reason.
+              let editFeature;
               completedRoutes.features = completedRoutes.features.filter(
-                (f) => f.properties.uid != edit.properties.uid
+                (f) => {
+                  if (f.properties.uid == editUid) {
+                    editFeature = f;
+                    return false;
+                  } else {
+                    return true;
+                  }
+                }
               );
               map.getSource("finished-routes").setData(completedRoutes);
 
-              routeSnapper.editExisting(edit);
+              routeSnapper.editExisting(editFeature);
             }
           }
         });

--- a/examples/index.html
+++ b/examples/index.html
@@ -76,6 +76,8 @@
         boxZoom: false,
       });
 
+      let routeSnapper;
+
       map.on("load", function () {
         map.addSource("boundary", {
           type: "geojson",
@@ -122,8 +124,11 @@
             "line-width": 5,
           },
         });
+        let idCounter = 0;
         let snapTool = document.getElementById("snap-tool");
         snapTool.addEventListener("new-route", (e) => {
+          // Assign a unique ID, so we can later delete it
+          e.detail.properties.uid = idCounter++;
           completedRoutes.features.push(e.detail);
           map.getSource("finished-routes").setData(completedRoutes);
           document.getElementById(
@@ -142,6 +147,29 @@
           completedRoutes.features = [];
           map.getSource("finished-routes").setData(completedRoutes);
         };
+
+        map.on("click", (e) => {
+          if (!routeSnapper || !routeSnapper.isActive()) {
+            let features = map.queryRenderedFeatures(e.point, {
+              layers: ["finished-routes"],
+            });
+            if (features.length > 0) {
+              // If multiple routes overlap, arbitrarily edit one of them
+              let edit = features[0];
+
+              // First remove the route from the completed set, so we don't
+              // have duplicates. Be careful with the comparison;
+              // queryRenderedFeatures doesn't have back a regular GeoJSON
+              // feature.
+              completedRoutes.features = completedRoutes.features.filter(
+                (f) => f.properties.uid != edit.properties.uid
+              );
+              map.getSource("finished-routes").setData(completedRoutes);
+
+              routeSnapper.editExisting(edit);
+            }
+          }
+        });
       });
 
       await init();
@@ -152,7 +180,7 @@
           url,
           document.getElementById("snap-progress")
         );
-        let routeSnapper = new RouteSnapper(
+        routeSnapper = new RouteSnapper(
           map,
           graphBytes,
           document.getElementById("snap-tool")

--- a/route-snapper/lib.js
+++ b/route-snapper/lib.js
@@ -155,9 +155,11 @@ export class RouteSnapper {
     // TODO Remove the event listeners on document and map
   }
 
+  // This takes a GeoJSON feature previously returned from the new-route event.
+  // It must have all properties returned originally.
   editExisting(feature) {
     this.#activeControl();
-    this.inner.editExisting(JSON.stringify(feature));
+    this.inner.editExisting(feature.properties.waypoints);
     this.#redraw();
   }
 

--- a/route-snapper/lib.js
+++ b/route-snapper/lib.js
@@ -155,6 +155,12 @@ export class RouteSnapper {
     // TODO Remove the event listeners on document and map
   }
 
+  editExisting(feature) {
+    this.#activeControl();
+    this.inner.editExisting(JSON.stringify(feature));
+    this.#redraw();
+  }
+
   #inactiveControl() {
     this.active = false;
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -93,6 +93,9 @@ There are a few methods on the `RouteSnapper` object you can call:
 - `setConfig` to change some settings
   - `avoid_doubling_back` (disabled by default): When possible, avoid edges
     already crossed for handling intermediate waypoints
+- `editExisting` to restart the tool with a previously created route. See notes
+  in [the example](https://github.com/dabreegster/route_snapper/blob/main/examples/index.html)
+  about how to call it.
 
 ### MapLibre gotchas
 


### PR DESCRIPTION
Previously, the tool couldn't do anything after finishing a route. This PR fixes this:

https://user-images.githubusercontent.com/1664407/228551119-68bdfae5-f9e1-4722-88b7-91ef601bb757.mp4

The implementation is to return extra state in the GeoJSON feature to let us reconstruct the waypoints. In my first commit, I just use the final geometry's first and last point, but of course this loses any middle waypoints dragged around, and can't handle freehand points. In the second, I just encode the waypoints in the output, and require callers to pass back in the feature with this extra property.

Possible bugs/problems:
- If a route was drawn with an option, like `avoidDoublingBack`, when the route is restored, it'll be subject to the new setting and may change. I'll leave it as future work to plumb through and retain that option too.
- In a real setting, we'll be saving drawn routes and editing them many months later, when the route snapper input graph might've changed with new OSM data. We'll just snap the waypoints to the closest match in the new graph. It should be correct most of the time, but there might be some exotic case where OSM geometry changes and causes a re-edited route to jump around a bit.

Alternate implementation considered: We could try to use only the line-string and not plumb back extra properties. Every single point would be a waypoint, either snapped if it's close enough to a node, or freehand otherwise. Then we could iteratively try to remove intermediate points as waypoints and see if the shortest path matches the original geometry. This would be slower and much more complex. The cost of serializing waypoints is negligible.

Asking @robinlovelace-ate and @Sparrow0hawk for a review. I'll release a new version of this package, then open another PR in ATIP to integrate this.