### PR TITLE
Start a new mode to draw area polygons snapped to roads! https://gith…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ this and want to give feedback on API changes.
 
 ## Unreleased
 
+- Add an optional mode to draw closed areas
+
 ## 0.1.12
 
 - Adjust when the `activate` event is fired

--- a/examples/index.html
+++ b/examples/index.html
@@ -135,10 +135,21 @@
         map.addLayer({
           id: "finished-routes",
           source: "finished-routes",
+          filter: ["in", "$type", "LineString"],
           type: "line",
           paint: {
             "line-color": "blue",
             "line-width": 5,
+          },
+        });
+        map.addLayer({
+          id: "finished-areas",
+          source: "finished-routes",
+          filter: ["in", "$type", "Polygon"],
+          type: "fill",
+          paint: {
+            "fill-color": "blue",
+            "fill-opacity": 0.2,
           },
         });
         let idCounter = 0;
@@ -175,7 +186,7 @@
         map.on("click", (e) => {
           if (!routeSnapper || !routeSnapper.isActive()) {
             let features = map.queryRenderedFeatures(e.point, {
-              layers: ["finished-routes"],
+              layers: ["finished-routes", "finished-areas"],
             });
             if (features.length > 0) {
               // If multiple routes overlap, arbitrarily edit one of them

--- a/user_guide.md
+++ b/user_guide.md
@@ -97,6 +97,8 @@ There are a few methods on the `RouteSnapper` object you can call:
 - `setConfig` to change some settings
   - `avoid_doubling_back` (disabled by default): When possible, avoid edges
     already crossed for handling intermediate waypoints
+  - `area_mode` (disabled by default): Produce closed polygons instead of
+    line-strings.
 - `editExisting` to restart the tool with a previously created route. See notes
   in [the example](https://github.com/dabreegster/route_snapper/blob/main/examples/index.html)
   about how to call it.


### PR DESCRIPTION
…ub.com/acteng/atip/issues/118

https://user-images.githubusercontent.com/1664407/234846559-0eb00fde-c395-46d5-89f1-45f23e5517ad.mp4

Here's a working area drawing tool that snaps to roads! It's a bit clunky, but I'm happy with it as a v1. I'll followup with a PR in ATIP to integrate it.

Some of the unsolved bugs / design warts:
- No attempt to "backfill" or import an existing polygon produced in another tool. You can edit a polygon made with this tool only.
- No freehand points at all in this mode. We can relax this constraint later, but it gets tricky. For now, I'm picturing two separate polygon tools in ATIP -- the current freehand one and this one. Won't be able to mix and match yet.
- You can delete waypoints by clicking them, unless it happens to be the first waypoint, which is a bit special internally.
- Sometimes a waypoint winds up looking like a linear route that doubles back on itself; the resulting polygon is a bit broken. The user can visually avoid this; it's obvious when it goes wrong.
- After drawing a closed polygon, I've sometimes clicked and managed to incorrectly insert a new waypoint at the very end, creating a linestring that escapes the polygon. This is incorrect / a bug. I can't repro yet; I'll click more carefully in future tests. :)

CC @robinlovelace-ate and @Sparrow0hawk. Async code review always welcome