### PR TITLE
Let the user opt into the interaction of extending the route more

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@ this and want to give feedback on API changes.
 
 ## Unreleased
 
+- Fix bugs where built-in controls can get out-of-sync with current settings
+- By default, don't keep drawing more points to the end of the route
+- Fix bug that created a new waypoint when clicking (and not dragging) an
+  intermediate point
+
 ## 0.1.13
 
 - Add an optional mode to draw closed areas

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ this and want to give feedback on API changes.
 - By default, don't keep drawing more points to the end of the route
 - Fix bug that created a new waypoint when clicking (and not dragging) an
   intermediate point
+- Double click to end a route
 
 ## 0.1.13
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -91,6 +91,7 @@
         center: [-0.0961, 51.4922],
         zoom: 13,
         boxZoom: false,
+        doubleClickZoom: false,
       });
 
       let routeSnapper;

--- a/route-snapper/lib.js
+++ b/route-snapper/lib.js
@@ -216,7 +216,7 @@ export class RouteSnapper {
       this.inner.setConfig({
         avoid_doubling_back: true,
         area_mode: true,
-        extend_route: false,
+        extend_route: true,
       });
     }
 

--- a/route-snapper/lib.js
+++ b/route-snapper/lib.js
@@ -103,6 +103,16 @@ export class RouteSnapper {
         this.#redraw();
       });
 
+      this.map.on("dblclick", () => {
+        if (!this.active) {
+          return;
+        }
+        // Treat it like a click, to possibly add a final point
+        this.inner.onClick();
+        // But then finish
+        this.#finishSnapping();
+      });
+
       this.map.on("dragstart", (e) => {
         if (!this.active) {
           return;
@@ -281,7 +291,7 @@ export class RouteSnapper {
       <li>Hold <b>Shift</b> to draw a point anywhere</li>
       <li><b>Click and drag</b> any point to move it</li>
       <li><b>Click</b> a red waypoint to delete it</li>
-      <li>Press <b>Enter</b> to finish route</li>
+      <li>Press <b>Enter</b> or <b>double click</b> to finish route</li>
       <li>Press <b>Escape</b> to cancel and discard route</li>
     </ul>
     `;

--- a/route-snapper/lib.js
+++ b/route-snapper/lib.js
@@ -216,6 +216,7 @@ export class RouteSnapper {
       this.inner.setConfig({
         avoid_doubling_back: true,
         area_mode: true,
+        extend_route: false,
       });
     }
 
@@ -264,6 +265,12 @@ export class RouteSnapper {
     </div>
     <div>
       <label>
+        <input type="checkbox" id="extendRoute" />
+        Extend the route
+      </label>
+    </div>
+    <div>
+      <label>
         <input type="checkbox" id="areaMode" />
         Area mode
       </label>
@@ -288,18 +295,23 @@ export class RouteSnapper {
     };
     let avoidDoublingBack = document.getElementById("avoidDoublingBack");
     let areaMode = document.getElementById("areaMode");
+    let extendRoute = document.getElementById("extendRoute");
     avoidDoublingBack.onclick = () => {
       this.inner.setConfig({
         avoid_doubling_back: avoidDoublingBack.checked,
         area_mode: areaMode.checked,
+        extend_route: extendRoute.checked,
       });
       this.#redraw();
     };
+    extendRoute.onclick = avoidDoublingBack.onclick;
     areaMode.onclick = () => {
       avoidDoublingBack.checked = true;
+      extendRoute.checked = true;
       this.inner.setConfig({
         avoid_doubling_back: avoidDoublingBack.checked,
         area_mode: areaMode.checked,
+        extend_route: extendRoute.checked,
       });
       this.#redraw();
     };
@@ -307,6 +319,7 @@ export class RouteSnapper {
     // Sync checkboxes with the tool's current state, from the last time it was used
     let config = JSON.parse(this.inner.getConfig());
     avoidDoublingBack.checked = config.avoid_doubling_back;
+    extendRoute.checked = config.extend_route;
     areaMode.checked = config.area_mode;
   }
 

--- a/route-snapper/src/lib.rs
+++ b/route-snapper/src/lib.rs
@@ -27,8 +27,13 @@ pub struct JsRouteSnapper {
 
 #[derive(Default, Serialize, Deserialize)]
 struct Config {
+    /// With multiple intermediate waypoints, try to avoid routing on edges already used in a
+    /// previous portion of the path. This is best-effort.
     avoid_doubling_back: bool,
+    /// Generate a route that starts and ends in the same place.
     area_mode: bool,
+    /// If false, the user can only drag waypoints after specifying the start and end of the route.
+    /// If true, they can keep clicking to extend the end of the route.
     extend_route: bool,
 }
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -109,7 +109,8 @@ There are a few methods on the `RouteSnapper` object you can call:
 
 You must specify `boxZoom: false` when creating your
 [Map](https://maplibre.org/maplibre-gl-js-docs/api/map/), or shift-click for
-drawing freehand points won't work.
+drawing freehand points won't work. Likewise, you need to disable
+`doubleClickZoom` so that you can double click to end a route.
 
 ### Using with mapbox-gl-draw
 


### PR DESCRIPTION
https://github.com/dabreegster/route_snapper/assets/1664407/d76f0e3d-99dc-413b-b523-57a696fd4ff9

From user testing, we've found that people are confused about how to finish drawing a route, and also the experience of adjusting existing waypoints by dragging them is hard. Both problems are exasperated by how the route tool keeps trying to append more points to the end of the route. So by default, stop doing that. For users who want to opt into this behavior, they can enable the setting and continue drawing a route by gradually adding more points to the end.

CC @Pete-Y-CS and @Sparrow0hawk for review. Once we commit this here and I release a new NPM version, we can pull it into ATIP (and add a similar checkbox there for toggling the behavior).