### PR TITLE
Fix geometry when the intersection polygon center differs too much from

### DIFF
--- a/osm-to-route-snapper/src/main.rs
+++ b/osm-to-route-snapper/src/main.rs
@@ -54,7 +54,16 @@ fn streets_to_snapper(streets: &osm2streets::StreetNetwork) -> RouteSnapperMap {
         if i.roads.iter().all(|r| streets.roads[r].is_light_rail()) {
             continue;
         }
-        map.nodes.push(i.polygon.center());
+
+        // The intersection's calculated polygon might not match up with road reference lines.
+        // Instead use an endpoint of any connecting road's reference line.
+        let road = &streets.roads[&i.roads[0]];
+        map.nodes.push(if road.src_i == i.id {
+            road.reference_line.first_pt()
+        } else {
+            road.reference_line.last_pt()
+        });
+
         id_lookup.insert(i.id, NodeID(id_lookup.len() as u32));
     }
     for r in streets.roads.values() {


### PR DESCRIPTION
road reference lines (https://github.com/acteng/atip/issues/255)

The specific problem in Surrey is fixed:
![Screenshot from 2023-07-03 09-00-51](https://github.com/dabreegster/route_snapper/assets/1664407/aaeda539-8601-478b-8f3a-43044029eaec)
![Screenshot from 2023-07-03 08-57-50](https://github.com/dabreegster/route_snapper/assets/1664407/ea3a1a0f-3cb8-44c8-a4fb-1c2de154d13d)
And there are no visible changes/regressions elsewhere