### PR TITLE
Add a page to easily create graph files from OSM data

### DIFF
--- a/examples/import.html
+++ b/examples/import.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Create route-snapper graph files from OSM</title>
+    <meta
+      name="viewport"
+      content="initial-scale=1,maximum-scale=1,user-scalable=no"
+    />
+    <script src="https://unpkg.com/maplibre-gl@3.1.0/dist/maplibre-gl.js"></script>
+    <link
+      href="https://unpkg.com/maplibre-gl@3.1.0/dist/maplibre-gl.css"
+      rel="stylesheet"
+    />
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #map {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 100%;
+      }
+
+      #top-left {
+        position: absolute;
+        z-index: 5;
+        padding: 20px;
+        max-width: 400px;
+        background-color: white;
+      }
+
+      .maplibregl-ctrl-group button {
+        width: 70px;
+        height: 70px;
+      }
+
+      .mapbox-gl-draw_polygon {
+        background-size: 80px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="top-left">
+      <p>
+        Use the polygon tool on the top-right to select an area to import.
+        (Double click or press enter to finish.) Wait a bit, then your browser
+        should download a file. Use "Change graph file" in the
+        <a href="index.html">main tool</a> to load it.
+      </p>
+      <p>
+        Thanks to
+        <a
+          href="https://wiki.openstreetmap.org/wiki/Overpass_API"
+          target="_blank"
+          >Overpass</a
+        >
+        for making OpenStreetMap extracts easy!
+      </p>
+      <p id="status"></p>
+    </div>
+
+    <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.4.1/mapbox-gl-draw.js"></script>
+    <link
+      rel="stylesheet"
+      href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.4.1/mapbox-gl-draw.css"
+      type="text/css"
+    />
+    <div id="map"></div>
+
+    <script type="module">
+      import init, {
+        convert,
+      } from "./osm-to-route-snapper/pkg/osm_to_route_snapper.js";
+
+      await init();
+
+      let map = new maplibregl.Map({
+        container: "map",
+        style:
+          "https://api.maptiler.com/maps/streets/style.json?key=MZEJTanw3WpxRvt7qDfo",
+        hash: true,
+      });
+
+      // TODO Hack from https://github.com/maplibre/maplibre-gl-js/issues/2601.
+      MapboxDraw.constants.classes.CONTROL_BASE = "maplibregl-ctrl";
+      MapboxDraw.constants.classes.CONTROL_PREFIX = "maplibregl-ctrl-";
+      MapboxDraw.constants.classes.CONTROL_GROUP = "maplibregl-ctrl-group";
+      let draw = new MapboxDraw({
+        displayControlsDefault: false,
+        controls: {
+          polygon: true,
+        },
+      });
+      map.addControl(draw);
+
+      map.on("draw.create", importPolygon);
+
+      async function importPolygon(e) {
+        let polygon = e.features[0];
+        draw.deleteAll();
+        let status = document.getElementById("status");
+
+        status.textContent = "Fetching from Overpass";
+        let resp = await fetch(overpassQueryForPolygon(polygon));
+        let osmXml = await resp.text();
+
+        status.textContent = `Importing OSM data (${osmXml.length} bytes) with osm2streets`;
+        let bytes = convert(osmXml, JSON.stringify(polygon));
+        status.textContent = `Graph file (${bytes.length} bytes) done, downloading`;
+        downloadGeneratedFile(bytes, "route-snapper-graph.bin");
+      }
+
+      // Construct a query to extract all XML data in the polygon clip. See
+      // https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL
+      function overpassQueryForPolygon(feature) {
+        let filter = 'poly:"';
+        for (let [lng, lat] of feature.geometry.coordinates[0]) {
+          filter += `${lat} ${lng} `;
+        }
+        filter = filter.slice(0, -1) + '"';
+        let query = `(nwr(${filter}); node(w)->.x; <;); out meta;`;
+        return `https://overpass-api.de/api/interpreter?data=${query}`;
+      }
+
+      function downloadGeneratedFile(bytes, filename) {
+        let blob = new Blob([bytes], { type: "application/octet-stream" });
+        let url = URL.createObjectURL(blob);
+
+        let link = document.createElement("a");
+        link.href = url;
+        link.download = filename;
+        link.style.display = "none";
+
+        document.body.appendChild(link);
+        link.click();
+
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+      }
+    </script>
+  </body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -49,6 +49,9 @@
   <body>
     <div id="top-left">
       <div class="row">
+        <a href="import.html">Create your own graph files</a>
+      </div>
+      <div class="row">
         <label
           >Change graph file:
           <input type="file" id="fileInput" />

--- a/examples/osm-to-route-snapper
+++ b/examples/osm-to-route-snapper
@@ -1,0 +1,1 @@
+../osm-to-route-snapper/

--- a/examples/serve_locally.sh
+++ b/examples/serve_locally.sh
@@ -2,5 +2,6 @@
 
 set -e
 wasm-pack build --release --target web ../route-snapper
+wasm-pack build --release --target web ../osm-to-route-snapper
 cp ../route-snapper/lib.js ../route-snapper/pkg
 python3 -m http.server --directory .

--- a/osm-to-route-snapper/Cargo.lock
+++ b/osm-to-route-snapper/Cargo.lock
@@ -148,6 +148,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "console_log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +393,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -574,10 +587,17 @@ dependencies = [
  "abstutil",
  "bincode",
  "clap",
+ "console_error_panic_hook",
+ "console_log",
  "geom",
+ "instant",
+ "log",
  "osm2streets",
  "route-snapper-graph",
+ "serde-wasm-bindgen",
  "streets_reader",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -795,6 +815,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/osm-to-route-snapper/Cargo.toml
+++ b/osm-to-route-snapper/Cargo.toml
@@ -3,11 +3,26 @@ name = "osm-to-route-snapper"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 abstutil = { git = "https://github.com/a-b-street/abstreet" }
 bincode = "1.3.1"
-clap = { version = "4.0.32", features = ["derive"] }
 geom = { git = "https://github.com/a-b-street/abstreet" }
 osm2streets = { git = "https://github.com/a-b-street/osm2streets" }
 route-snapper-graph = { path = "../route-snapper-graph" }
 streets_reader = { git = "https://github.com/a-b-street/osm2streets" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+clap = { version = "4.0.32", features = ["derive"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = "0.1.6"
+console_log = "0.2.0"
+# TODO Upstream this in abstutil crate. WASM is missing some runtime dep otherwise.
+instant = { version = "0.1.12", features = ["wasm-bindgen"] }
+log = "0.4.17"
+serde-wasm-bindgen = "0.4.5"
+wasm-bindgen = "0.2.70"
+web-sys = { version = "0.3.6", features = ["console"] }

--- a/osm-to-route-snapper/src/lib.rs
+++ b/osm-to-route-snapper/src/lib.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+
+use abstutil::Timer;
+use geom::LonLat;
+
+use route_snapper_graph::{Edge, NodeID, RouteSnapperMap};
+
+/// Convert input OSM XML data and a boundary GeoJSON string (with exactly one polygon) into a
+/// RouteSnapperMap, which can then be serialized and used.
+pub fn convert_osm(input_osm: String, boundary_geojson: Option<String>) -> RouteSnapperMap {
+    let mut timer = Timer::new("convert OSM to route snapper graph");
+
+    let (streets, _) = streets_reader::osm_to_street_network(
+        &input_osm,
+        boundary_geojson.map(|geojson| {
+            let mut polygons = LonLat::parse_geojson_polygons(geojson).unwrap();
+            if polygons.len() != 1 {
+                panic!("boundary_geojson doesn't contain exactly one polygon");
+            }
+            polygons.pop().unwrap().0
+        }),
+        osm2streets::MapConfig::default(),
+        &mut timer,
+    )
+    .unwrap();
+    streets_to_snapper(&streets)
+}
+
+fn streets_to_snapper(streets: &osm2streets::StreetNetwork) -> RouteSnapperMap {
+    let mut map = RouteSnapperMap {
+        gps_bounds: streets.gps_bounds.clone(),
+        nodes: Vec::new(),
+        edges: Vec::new(),
+    };
+
+    let mut id_lookup = HashMap::new();
+    for i in streets.intersections.values() {
+        if i.roads.iter().all(|r| streets.roads[r].is_light_rail()) {
+            continue;
+        }
+
+        // The intersection's calculated polygon might not match up with road reference lines.
+        // Instead use an endpoint of any connecting road's reference line.
+        let road = &streets.roads[&i.roads[0]];
+        map.nodes.push(if road.src_i == i.id {
+            road.reference_line.first_pt()
+        } else {
+            road.reference_line.last_pt()
+        });
+
+        id_lookup.insert(i.id, NodeID(id_lookup.len() as u32));
+    }
+    for r in streets.roads.values() {
+        if r.is_light_rail() {
+            continue;
+        }
+        map.edges.push(Edge {
+            node1: id_lookup[&r.src_i],
+            node2: id_lookup[&r.dst_i],
+            geometry: r.reference_line.clone(),
+            length: r.reference_line.length(),
+        });
+    }
+
+    map
+}
+
+#[cfg(target_arch = "wasm32")]
+use std::sync::Once;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+static START: Once = Once::new();
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen()]
+pub fn convert(input_osm: String, boundary_geojson: String) -> Vec<u8> {
+    START.call_once(|| {
+        console_log::init_with_level(log::Level::Info).unwrap();
+        console_error_panic_hook::set_once();
+    });
+
+    let snapper = convert_osm(input_osm, Some(boundary_geojson));
+    bincode::serialize(&snapper).unwrap()
+}

--- a/osm-to-route-snapper/src/main.rs
+++ b/osm-to-route-snapper/src/main.rs
@@ -1,12 +1,8 @@
-use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufWriter;
 
-use abstutil::Timer;
 use clap::Parser;
-use geom::LonLat;
-
-use route_snapper_graph::{Edge, NodeID, RouteSnapperMap};
+use osm_to_route_snapper::convert_osm;
 
 #[derive(Parser)]
 struct Args {
@@ -25,58 +21,12 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
-
-    let mut timer = Timer::new("convert OSM to route snapper graph");
-
-    let (streets, _) = streets_reader::osm_to_street_network(
-        &std::fs::read_to_string(args.input_osm).unwrap(),
+    let snapper = convert_osm(
+        std::fs::read_to_string(args.input_osm).unwrap(),
         args.boundary
-            .map(|path| LonLat::read_geojson_polygon(&path).unwrap()),
-        osm2streets::MapConfig::default(),
-        &mut timer,
-    )
-    .unwrap();
-    let snapper = streets_to_snapper(&streets);
+            .map(|path| std::fs::read_to_string(path).unwrap()),
+    );
 
     let output = BufWriter::new(File::create(args.output).unwrap());
     bincode::serialize_into(output, &snapper).unwrap();
-}
-
-fn streets_to_snapper(streets: &osm2streets::StreetNetwork) -> RouteSnapperMap {
-    let mut map = RouteSnapperMap {
-        gps_bounds: streets.gps_bounds.clone(),
-        nodes: Vec::new(),
-        edges: Vec::new(),
-    };
-
-    let mut id_lookup = HashMap::new();
-    for i in streets.intersections.values() {
-        if i.roads.iter().all(|r| streets.roads[r].is_light_rail()) {
-            continue;
-        }
-
-        // The intersection's calculated polygon might not match up with road reference lines.
-        // Instead use an endpoint of any connecting road's reference line.
-        let road = &streets.roads[&i.roads[0]];
-        map.nodes.push(if road.src_i == i.id {
-            road.reference_line.first_pt()
-        } else {
-            road.reference_line.last_pt()
-        });
-
-        id_lookup.insert(i.id, NodeID(id_lookup.len() as u32));
-    }
-    for r in streets.roads.values() {
-        if r.is_light_rail() {
-            continue;
-        }
-        map.edges.push(Edge {
-            node1: id_lookup[&r.src_i],
-            node2: id_lookup[&r.dst_i],
-            geometry: r.reference_line.clone(),
-            length: r.reference_line.length(),
-        });
-    }
-
-    map
 }

--- a/user_guide.md
+++ b/user_guide.md
@@ -8,11 +8,13 @@ that has coordinates defined for the edges.
 
 A common use case is routing along a street network. You can create an example
 file from OpenStreetMap data using
-[osm2streets](https://github.com/a-b-street/osm2streets). You need an
-`.osm.xml` file, and optionally a GeoJSON file with one polygon representing
-the boundary of your area.
+[osm2streets](https://github.com/a-b-street/osm2streets). The easiest way to do
+this for smaller areas is [in your web
+browser](https://dabreegster.github.io/route_snapper/import.html).
 
-You'll need to [install Rust](https://www.rust-lang.org/tools/install) to run this:
+For larger areas, you need an `.osm.xml` file, and optionally a GeoJSON file
+with one polygon representing the boundary of your area. You'll need to
+[install Rust](https://www.rust-lang.org/tools/install) to run this:
 
 ```
 cd osm-to-route-snapper


### PR DESCRIPTION
Closes #28

Just draw a polygon (size limited by Overpass / your connection / CPU speed), download the file:

https://github.com/dabreegster/route_snapper/assets/1664407/a0e7b440-aadb-4428-af8f-2826c16e4b8b

Then load the file to try it out:

https://github.com/dabreegster/route_snapper/assets/1664407/8f4651be-eee7-49db-a9e2-7f1d922132f0

This is very handy for people to get started with the tool without needing to build anything locally. And it would've made debugging https://github.com/acteng/atip/issues/255 much faster, to clip the buggy area.