### PR TITLE
Trim precision of output coordinates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ this and want to give feedback on API changes.
 
 ## Unreleased
 
+- Output GeoJSON precision is now trimmed to 6 decimal places
 - `fetchWithProgress` now takes a callback to return the progress as a percentage to the user.
 - Add `debugRenderGraph` and `changeGraph` APIs
 - Split `setConfig` into `setRouteConfig` and `setAreaMode` to prevent incorrect configuration


### PR DESCRIPTION
@robinlovelace-ate pointed out ATIP's geojson output is unnecessarily large due to coordinate precision. This PR trims to 6 decimal places, recommended by the GJ spec. https://github.com/acteng/atip/issues/252
CC @Pete-Y-CS as FYI too