### PR TITLE
Switch between snapped and freehand points

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ this and want to give feedback on API changes.
 - Change the `renderGeojson` output to distinguish snapped and freehand waypoints
 - Include a `cursor` property in the `renderGeojson` output
 - Distinguish hovered points in the `renderGeojson` output
+- Use a keypress to toggle snap/freehand mode, instead of holding down a key
+- Convert existing nodes between snapped/freehand
 
 ## 0.2.1
 

--- a/route-snapper/lib.js
+++ b/route-snapper/lib.js
@@ -139,26 +139,9 @@ export class RouteSnapper {
         if (e.key == "Enter") {
           e.preventDefault();
           this.#finishSnapping();
-        }
-      });
-
-      document.addEventListener("keydown", (e) => {
-        if (!this.active) {
-          return;
-        }
-        if (e.key == "Shift") {
+        } else if (e.key == "s") {
           e.preventDefault();
-          this.inner.setSnapMode(false);
-          this.#redraw();
-        }
-      });
-      document.addEventListener("keyup", (e) => {
-        if (!this.active) {
-          return;
-        }
-        if (e.key == "Shift") {
-          e.preventDefault();
-          this.inner.setSnapMode(true);
+          this.inner.toggleSnapMode();
           this.#redraw();
         }
       });
@@ -289,9 +272,13 @@ export class RouteSnapper {
       </label>
     </div>
 
+    <div id="snap_mode" style="background: red;">
+      Snapping to transport network
+    </div>
+
     <ul>
       <li><b>Click</b> green points on the transport network</br>to create snapped routes</li>
-      <li>Hold <b>Shift</b> to draw a point anywhere</li>
+      <li>Press <b>s</b> to toggle snapping / freehand mode</li>
       <li><b>Click and drag</b> any point to move it</li>
       <li><b>Click</b> a red waypoint to delete it</li>
       <li>Press <b>Enter</b> or <b>double click</b> to finish route</li>
@@ -366,6 +353,19 @@ export class RouteSnapper {
       let gj = JSON.parse(this.inner.renderGeojson());
       this.map.getSource("route-snapper").setData(gj);
       this.map.getCanvas().style.cursor = gj.cursor;
+
+      // TODO Detect changes, don't do this constantly?
+      let snapDiv = document.getElementById("snap_mode");
+      if (!snapDiv) {
+        return;
+      }
+      if (gj.snap_mode) {
+        snapDiv.style = "background: red";
+        snapDiv.innerHtml = "Snapping to transport network";
+      } else {
+        snapDiv.style = "background: blue";
+        snapDiv.innerHtml = "Drawing freehand points";
+      }
     }
   }
 }

--- a/route-snapper/src/lib.rs
+++ b/route-snapper/src/lib.rs
@@ -189,6 +189,7 @@ impl JsRouteSnapper {
     /// Enables area mode, where the snapper produces polygons.
     #[wasm_bindgen(js_name = setAreaMode)]
     pub fn set_area_mode(&mut self) {
+        self.snap_mode = true;
         self.router.config = Config {
             avoid_doubling_back: true,
             extend_route: true,

--- a/user_guide.md
+++ b/user_guide.md
@@ -117,11 +117,13 @@ There are a few methods on the `RouteSnapper` object you can call:
   - It'll include a LineString showing the confirmed route and also any speculative addition, based on the current state.
   - In area mode, it'll have a Polygon once there are at least 3 points.
   - It'll include a Point for every graph node involved in the current route. These will have a `type` property that's either `snapped-waypoint`, `free-waypoint`, or just `node` to indicate a draggable node that hasn't been touched yet. One Point may also have a `"hovered": true` property to indicate the mouse is currently on that Point.
-  - The GeoJSON object will also contain one foreign member called `cursor` to indicate the current mode of the tool. The values can be set to `map.getCanvas().style.cursor` as desired.
+  - The GeoJSON object will also contain a foreign member called `cursor` to indicate the current mode of the tool. The values can be set to `map.getCanvas().style.cursor` as desired.
     - `inherit`: The user is just idling on the map, not interacting with the map
     - `pointer`: The user is hovering on some node
     - `grabbing`: The user is actively dragging a node
     - `crosshair`: The user is choosing a location for a new freehand point. If they click, the point will be added.
+  - The GeoJSON object will also have a boolean foreign member called `snap_mode`.
+- `toggleSnapMode` attempts to switch between snapping and freehand drawing. It may not succeed.
 
 ### MapLibre gotchas
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -113,6 +113,11 @@ There are a few methods on the `RouteSnapper` object you can call:
 - `routeNameForWaypoints` takes the `feature.properties.waypoints` and returns
   a name describing the first and last waypoint (useful only for snapped
   waypoints).
+
+### WASM API
+
+If you're using the WASM API directly, the best reference is currently [the code](https://github.com/dabreegster/route_snapper/blob/main/route-snapper/src/lib.rs). Some particulars:
+
 - `renderGeojson` returns a GeoJSON FeatureCollection to render the current state of the tool.
   - It'll include a LineString showing the confirmed route and also any speculative addition, based on the current state.
   - In area mode, it'll have a Polygon once there are at least 3 points.


### PR DESCRIPTION
Fixes #25. This lets users fluidly transition between snapped and freehand points for drawing routes. It also changes from holding the Shift key to make freehand points to tapping a key to toggle.

https://github.com/dabreegster/route_snapper/assets/1664407/81399b06-dd45-43c4-93f0-03877af32494

Note the legend is the default in this JS library, but it'll be nicer in ATIP.

The next thing that seems useful after this is the ability to insert new freehand points along a segment and drag them around.