### PR TITLE
Start route-snapper-ts package

### DIFF
--- a/route-snapper-ts/.gitignore
+++ b/route-snapper-ts/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/route-snapper-ts/package-lock.json
+++ b/route-snapper-ts/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "route-snapper-ts",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "route-snapper-ts",
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/geojson": "^7946.0.14",
+        "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
+      "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/route-snapper-ts/package-lock.json
+++ b/route-snapper-ts/package-lock.json
@@ -8,16 +8,488 @@
       "name": "route-snapper-ts",
       "version": "0.0.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "maplibre-gl": "^4.0.0",
+        "route-snapper": "^0.4.0"
+      },
       "devDependencies": {
         "@types/geojson": "^7946.0.14",
         "typescript": "^5.4.5"
       }
     },
+    "node_modules/@mapbox/geojson-rewind": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
+      "dependencies": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz",
+      "integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA=="
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw=="
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "20.2.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.2.0.tgz",
+      "integrity": "sha512-BTw6/3ysowky22QMtNDjElp+YLwwvBDh3xxnq1izDFjTtUERm5nYSihlNZ6QaxXb+6lX2T2t0hBEjheAI+kBEQ==",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "sort-object": "^3.0.3",
+        "tinyqueue": "^2.0.3"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.14",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
-      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
-      "dev": true
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
+    },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/junit-report-builder": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/junit-report-builder/-/junit-report-builder-3.0.2.tgz",
+      "integrity": "sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA=="
+    },
+    "node_modules/@types/mapbox__point-geometry": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA=="
+    },
+    "node_modules/@types/mapbox__vector-tile": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
+      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/mapbox__point-geometry": "*",
+        "@types/pbf": "*"
+      }
+    },
+    "node_modules/@types/pbf": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA=="
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bytewise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+      "dependencies": {
+        "bytewise-core": "^1.2.2",
+        "typewise": "^1.0.3"
+      }
+    },
+    "node_modules/bytewise-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+      "dependencies": {
+        "typewise-core": "^1.2"
+      }
+    },
+    "node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/geojson-vt": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
+      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q=="
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/maplibre-gl": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.2.0.tgz",
+      "integrity": "sha512-x5GgYyKKn5UDvbUZFK7ng3Pq829/uYWDSVN/itZoP2slWSzKbjIXKi/Qhz5FnYiMXwpRgM08UIcVjtn1PLK9Tg==",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^20.2.0",
+        "@types/geojson": "^7946.0.14",
+        "@types/geojson-vt": "3.2.5",
+        "@types/junit-report-builder": "^3.0.2",
+        "@types/mapbox__point-geometry": "^0.1.4",
+        "@types/mapbox__vector-tile": "^1.3.4",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
+        "earcut": "^2.2.4",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.4.3",
+        "global-prefix": "^3.0.0",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^2.0.0",
+        "quickselect": "^2.0.0",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
+    },
+    "node_modules/pbf": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/potpack": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
+      "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw=="
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
+    },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
+    "node_modules/route-snapper": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/route-snapper/-/route-snapper-0.4.0.tgz",
+      "integrity": "sha512-KDWDJlNgWGa2fAMZW3eO2joQk0l5xYn2ojfA5rrK5Jg73JD8B4viJhnVJVj8nEujZNBetTTFHsCtB4cEVaaCow=="
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
+    },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-asc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
+      "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-desc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
+      "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-object": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
+      "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
+      "dependencies": {
+        "bytewise": "^1.1.0",
+        "get-value": "^2.0.2",
+        "is-extendable": "^0.1.1",
+        "sort-asc": "^0.2.0",
+        "sort-desc": "^0.2.0",
+        "union-value": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
     },
     "node_modules/typescript": {
       "version": "5.4.5",
@@ -30,6 +502,54 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typewise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+      "dependencies": {
+        "typewise-core": "^1.2.0"
+      }
+    },
+    "node_modules/typewise-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg=="
+    },
+    "node_modules/union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vt-pbf": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+      "dependencies": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
+      }
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     }
   }

--- a/route-snapper-ts/package-lock.json
+++ b/route-snapper-ts/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@types/geojson": "^7946.0.14",
+        "prettier": "^3.2.5",
         "typescript": "^5.4.5"
       }
     },
@@ -369,6 +370,21 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
       "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw=="
+    },
+    "node_modules/prettier": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",

--- a/route-snapper-ts/package.json
+++ b/route-snapper-ts/package.json
@@ -1,13 +1,14 @@
 {
   "name": "route-snapper-ts",
   "description": "Draw routes in MapLibre snapped to a street network using client-side routing. TypeScript bindings",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/dabreegster/route_snapper"
   },
   "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist/"
   ],

--- a/route-snapper-ts/package.json
+++ b/route-snapper-ts/package.json
@@ -14,10 +14,12 @@
   "scripts": {
     "tsc": "tsc -p tsconfig.json",
     "prepublishOnly": "npm run tsc",
-    "prepare": "npm run prepublishOnly"
+    "prepare": "npm run prepublishOnly",
+    "fmt": "prettier --write ."
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.14",
+    "prettier": "^3.2.5",
     "typescript": "^5.4.5"
   },
   "dependencies": {

--- a/route-snapper-ts/package.json
+++ b/route-snapper-ts/package.json
@@ -19,5 +19,9 @@
   "devDependencies": {
     "@types/geojson": "^7946.0.14",
     "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "maplibre-gl": "^4.0.0",
+    "route-snapper": "^0.4.0"
   }
 }

--- a/route-snapper-ts/package.json
+++ b/route-snapper-ts/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "route-snapper-ts",
+  "description": "Draw routes in MapLibre snapped to a street network using client-side routing. TypeScript bindings",
+  "version": "0.0.1",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dabreegster/route_snapper"
+  },
+  "module": "./dist/index.js",
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "tsc": "tsc -p tsconfig.json",
+    "prepublishOnly": "npm run tsc",
+    "prepare": "npm run prepublishOnly"
+  },
+  "devDependencies": {
+    "@types/geojson": "^7946.0.14",
+    "typescript": "^5.4.5"
+  }
+}

--- a/route-snapper-ts/src/index.ts
+++ b/route-snapper-ts/src/index.ts
@@ -5,37 +5,39 @@ import { JsRouteSnapper } from "route-snapper";
 const snapDistancePixels = 30;
 
 interface Writable<T> {
-        set(value: T): void;
+  set(value: T): void;
 }
 
 // TODO This isn't complete
 export interface Props {
-        waypoints: Waypoint[];
+  waypoints: Waypoint[];
 }
 
 export interface Waypoint {
-        lon: number;
-        lat: number;
-        snapped: boolean;
+  lon: number;
+  lat: number;
+  snapped: boolean;
 }
 
 export class RouteTool {
   map: Map;
   inner: JsRouteSnapper;
   active: boolean;
-  eventListenersSuccess: ((
-    f: Feature<LineString | Polygon, Props>,
-  ) => void)[];
-  eventListenersUpdated: ((
-    f: Feature<LineString | Polygon, Props>,
-  ) => void)[];
+  eventListenersSuccess: ((f: Feature<LineString | Polygon, Props>) => void)[];
+  eventListenersUpdated: ((f: Feature<LineString | Polygon, Props>) => void)[];
   eventListenersFailure: (() => void)[];
 
   routeToolGj: Writable<GeoJSON>;
   snapMode: Writable<boolean>;
   undoLength: Writable<number>;
 
-  constructor(map: Map, graphBytes: Uint8Array, routeToolGj: Writable<GeoJSON>, snapMode: Writable<boolean>, undoLength: Writable<number>) {
+  constructor(
+    map: Map,
+    graphBytes: Uint8Array,
+    routeToolGj: Writable<GeoJSON>,
+    snapMode: Writable<boolean>,
+    undoLength: Writable<number>,
+  ) {
     this.map = map;
     console.time("Deserialize and setup JsRouteSnapper");
     this.inner = new JsRouteSnapper(graphBytes);
@@ -45,9 +47,9 @@ export class RouteTool {
     this.eventListenersUpdated = [];
     this.eventListenersFailure = [];
 
-          this.routeToolGj = routeToolGj;
-          this.snapMode = snapMode;
-          this.undoLength = undoLength;
+    this.routeToolGj = routeToolGj;
+    this.snapMode = snapMode;
+    this.undoLength = undoLength;
 
     this.map.on("mousemove", this.onMouseMove);
     this.map.on("click", this.onClick);

--- a/route-snapper-ts/src/index.ts
+++ b/route-snapper-ts/src/index.ts
@@ -1,0 +1,8 @@
+import type { FeatureCollection } from "geojson";
+
+export function example(): FeatureCollection {
+        return {
+                type: "FeatureCollection",
+                features: [],
+        };
+}

--- a/route-snapper-ts/src/index.ts
+++ b/route-snapper-ts/src/index.ts
@@ -1,8 +1,338 @@
-import type { FeatureCollection } from "geojson";
+import type { Feature, GeoJSON, LineString, Polygon, Position } from "geojson";
+import type { Map, MapMouseEvent } from "maplibre-gl";
+import { JsRouteSnapper } from "route-snapper";
 
-export function example(): FeatureCollection {
-        return {
-                type: "FeatureCollection",
-                features: [],
-        };
+const snapDistancePixels = 30;
+
+interface Writable<T> {
+        set(value: T): void;
+}
+
+// TODO This isn't complete
+export interface Props {
+        waypoints: Waypoint[];
+}
+
+export interface Waypoint {
+        lon: number;
+        lat: number;
+        snapped: boolean;
+}
+
+export class RouteTool {
+  map: Map;
+  inner: JsRouteSnapper;
+  active: boolean;
+  eventListenersSuccess: ((
+    f: Feature<LineString | Polygon, Props>,
+  ) => void)[];
+  eventListenersUpdated: ((
+    f: Feature<LineString | Polygon, Props>,
+  ) => void)[];
+  eventListenersFailure: (() => void)[];
+
+  routeToolGj: Writable<GeoJSON>;
+  snapMode: Writable<boolean>;
+  undoLength: Writable<number>;
+
+  constructor(map: Map, graphBytes: Uint8Array, routeToolGj: Writable<GeoJSON>, snapMode: Writable<boolean>, undoLength: Writable<number>) {
+    this.map = map;
+    console.time("Deserialize and setup JsRouteSnapper");
+    this.inner = new JsRouteSnapper(graphBytes);
+    console.timeEnd("Deserialize and setup JsRouteSnapper");
+    this.active = false;
+    this.eventListenersSuccess = [];
+    this.eventListenersUpdated = [];
+    this.eventListenersFailure = [];
+
+          this.routeToolGj = routeToolGj;
+          this.snapMode = snapMode;
+          this.undoLength = undoLength;
+
+    this.map.on("mousemove", this.onMouseMove);
+    this.map.on("click", this.onClick);
+    this.map.on("dblclick", this.onDoubleClick);
+    this.map.on("dragstart", this.onDragStart);
+    this.map.on("mouseup", this.onMouseUp);
+    document.addEventListener("keydown", this.onKeyDown);
+    document.addEventListener("keypress", this.onKeyPress);
+  }
+
+  tearDown() {
+    this.map.off("mousemove", this.onMouseMove);
+    this.map.off("click", this.onClick);
+    this.map.off("dblclick", this.onDoubleClick);
+    this.map.off("dragstart", this.onDragStart);
+    this.map.off("mouseup", this.onMouseUp);
+    document.removeEventListener("keydown", this.onKeyDown);
+    document.removeEventListener("keypress", this.onKeyPress);
+  }
+
+  onMouseMove = (e: MapMouseEvent) => {
+    if (!this.active) {
+      return;
+    }
+    const nearbyPoint: [number, number] = [
+      e.point.x - snapDistancePixels,
+      e.point.y,
+    ];
+    const circleRadiusMeters = this.map
+      .unproject(e.point)
+      .distanceTo(this.map.unproject(nearbyPoint));
+    if (
+      this.inner.onMouseMove(e.lngLat.lng, e.lngLat.lat, circleRadiusMeters)
+    ) {
+      this.redraw();
+      // TODO We'll call this too frequently
+      this.dataUpdated();
+    }
+  };
+
+  onClick = () => {
+    if (!this.active) {
+      return;
+    }
+    this.inner.onClick();
+    this.redraw();
+    this.dataUpdated();
+  };
+
+  onDoubleClick = (e: MapMouseEvent) => {
+    if (!this.active) {
+      return;
+    }
+    // When we finish, we'll re-enable doubleClickZoom, but we don't want this to zoom in
+    e.preventDefault();
+    // Double clicks happen as [click, click, dblclick]. The first click adds a
+    // point, the second immediately deletes it, and so we simulate a third
+    // click to add it again.
+    this.inner.onClick();
+    this.finish();
+  };
+
+  onDragStart = () => {
+    if (!this.active) {
+      return;
+    }
+    if (this.inner.onDragStart()) {
+      this.map.dragPan.disable();
+    }
+  };
+
+  onMouseUp = () => {
+    if (!this.active) {
+      return;
+    }
+    if (this.inner.onMouseUp()) {
+      this.map.dragPan.enable();
+    }
+  };
+
+  onKeyDown = (e: KeyboardEvent) => {
+    if (!this.active) {
+      return;
+    }
+    if (e.key == "Escape") {
+      e.stopPropagation();
+      this.cancel();
+    }
+  };
+
+  onKeyPress = (e: KeyboardEvent) => {
+    if (!this.active) {
+      return;
+    }
+    // Ignore keypresses if we're not focused on the map
+    if ((e.target as HTMLElement).tagName == "INPUT") {
+      return;
+    }
+
+    if (e.key == "Enter") {
+      e.stopPropagation();
+      this.finish();
+    } else if (e.key == "s" || e.key == "S") {
+      e.stopPropagation();
+      this.inner.toggleSnapMode();
+      this.redraw();
+    } else if (e.key == "z" && e.ctrlKey) {
+      this.undo();
+    }
+  };
+
+  // Activate the tool with blank state.
+  startRoute() {
+    // If we were already active, don't do anything
+    // TODO Or... error? Why'd this happen?
+    if (this.active) {
+      return;
+    }
+
+    this.active = true;
+
+    // Otherwise, shift+click breaks
+    this.map.boxZoom.disable();
+    // Otherwise, double clicking to finish breaks
+    this.map.doubleClickZoom.disable();
+  }
+
+  // Activate the tool with blank state.
+  startArea() {
+    // If we were already active, don't do anything
+    // TODO Or... error? Why'd this happen?
+    if (this.active) {
+      return;
+    }
+
+    this.inner.setAreaMode();
+    this.active = true;
+    this.map.boxZoom.disable();
+    this.map.doubleClickZoom.disable();
+  }
+
+  // Deactivate the tool, clearing all state. No events are fired for eventListenersFailure.
+  stop() {
+    this.active = false;
+    this.inner.clearState();
+    this.redraw();
+    this.map.boxZoom.enable();
+    this.map.doubleClickZoom.enable();
+  }
+
+  // This takes a GeoJSON feature previously returned. It must have all
+  // properties returned originally. If waypoints are missing (maybe because
+  // the route was produced by a different tool, or an older version of this
+  // tool), the edited line-string may differ from the input.
+  editExistingRoute(feature: Feature<LineString, Props>) {
+    if (this.active) {
+      window.alert("Bug: editExistingRoute called when tool is already active");
+    }
+
+    if (!feature.properties.waypoints) {
+      // Only use the first and last points as waypoints, and assume they're
+      // snapped. This only works for the simplest cases.
+      feature.properties.waypoints = [
+        {
+          lon: feature.geometry.coordinates[0][0],
+          lat: feature.geometry.coordinates[0][1],
+          snapped: true,
+        },
+        {
+          lon: feature.geometry.coordinates[
+            feature.geometry.coordinates.length - 1
+          ][0],
+          lat: feature.geometry.coordinates[
+            feature.geometry.coordinates.length - 1
+          ][1],
+          snapped: true,
+        },
+      ];
+    }
+
+    this.startRoute();
+    this.inner.editExisting(feature.properties.waypoints);
+    this.redraw();
+  }
+
+  // This only handles features previously returned by this tool.
+  editExistingArea(feature: Feature<Polygon, Props>) {
+    if (this.active) {
+      window.alert("Bug: editExistingArea called when tool is already active");
+    }
+
+    if (!feature.properties.waypoints) {
+      window.alert(
+        "Bug: editExistingArea called for a polygon not produced by the route-snapper",
+      );
+    }
+
+    this.startArea();
+    this.inner.editExisting(feature.properties.waypoints);
+    this.redraw();
+  }
+
+  addEventListenerSuccess(
+    callback: (f: Feature<LineString | Polygon, Props>) => void,
+  ) {
+    this.eventListenersSuccess.push(callback);
+  }
+  addEventListenerUpdated(
+    callback: (f: Feature<LineString | Polygon, Props>) => void,
+  ) {
+    this.eventListenersUpdated.push(callback);
+  }
+  addEventListenerFailure(callback: () => void) {
+    this.eventListenersFailure.push(callback);
+  }
+  clearEventListeners() {
+    this.eventListenersSuccess = [];
+    this.eventListenersUpdated = [];
+    this.eventListenersFailure = [];
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  // Either a success or failure event will happen, depending on current state
+  finish() {
+    let rawJSON = this.inner.toFinalFeature();
+    if (rawJSON) {
+      // Pass copies to each callback
+      for (let cb of this.eventListenersSuccess) {
+        cb(JSON.parse(rawJSON) as Feature<LineString | Polygon, Props>);
+      }
+    } else {
+      for (let cb of this.eventListenersFailure) {
+        cb();
+      }
+    }
+    this.stop();
+  }
+
+  // This stops the tool and fires a failure event
+  cancel() {
+    this.inner.clearState();
+    this.finish();
+  }
+
+  setRouteConfig(config: {
+    avoid_doubling_back: boolean;
+    extend_route: boolean;
+  }) {
+    this.inner.setRouteConfig(config);
+    this.redraw();
+  }
+
+  addSnappedWaypoint(pt: Position) {
+    this.inner.addSnappedWaypoint(pt[0], pt[1]);
+    this.redraw();
+  }
+
+  undo() {
+    this.inner.undo();
+    this.redraw();
+  }
+
+  toggleSnapMode() {
+    this.inner.toggleSnapMode();
+    this.redraw();
+  }
+
+  private redraw() {
+    let gj = JSON.parse(this.inner.renderGeojson());
+    this.routeToolGj.set(gj);
+    this.map.getCanvas().style.cursor = gj.cursor;
+    this.snapMode.set(gj.snap_mode);
+    this.undoLength.set(gj.undo_length);
+  }
+
+  private dataUpdated() {
+    let rawJSON = this.inner.toFinalFeature();
+    if (rawJSON) {
+      // Pass copies to each callback
+      for (let cb of this.eventListenersUpdated) {
+        cb(JSON.parse(rawJSON) as Feature<LineString | Polygon, Props>);
+      }
+    }
+  }
 }

--- a/route-snapper-ts/tsconfig.json
+++ b/route-snapper-ts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "ES2020",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "outDir": "./dist",
+    "declaration": true
+  },
+  "include": [
+    "./src"
+  ]
+}

--- a/route-snapper-ts/tsconfig.json
+++ b/route-snapper-ts/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ES2020",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
     "strict": true,
     "outDir": "./dist",
     "declaration": true

--- a/route-snapper-ts/tsconfig.json
+++ b/route-snapper-ts/tsconfig.json
@@ -9,7 +9,5 @@
     "outDir": "./dist",
     "declaration": true
   },
-  "include": [
-    "./src"
-  ]
+  "include": ["./src"]
 }


### PR DESCRIPTION
A start to #52 and #53. This starts a new -ts NPM package, [already published](https://www.npmjs.com/package/route-snapper-ts), that brings in the newer TS library wrapping the WASM API. Ultimately, I think the structure will be:

- `route-snapper-wasm`, just the auto-generated WASM library, probably with the not-great TS types, unless `tsify` or one of the other options works well
- `route-snapper-ts`, this new wrapper library
- Possibly a `route-snapper-svelte`, with a component for rendering to the map using `svelte-maplibre` and some controls. Both would be opinionated about the styles / wording and probably not configurable. Or maybe this package shouldn't exist, and it should just be example code that people copy and customize to incorporate in their apps.

Many steps after this one needed to set up some kind of proper TS docs, document the APIs nicely, write full types for the feature properties, and rethink the existing JS library and examples.

CC @tordans 