### PR TITLE
Update route snapper builders and user guide

### DIFF
--- a/geojson-to-route-snapper/src/main.rs
+++ b/geojson-to-route-snapper/src/main.rs
@@ -7,11 +7,11 @@ use geojson_to_route_snapper::convert_geojson;
 #[derive(Parser)]
 struct Args {
     /// Path to a .geojson file to convert
-    #[arg(long)]
+    #[arg(short, long)]
     input: String,
 
     /// Output file to write
-    #[arg(long, default_value = "snap.bin")]
+    #[arg(short, long, default_value = "snap.bin")]
     output: String,
 }
 

--- a/osm-to-route-snapper/src/lib.rs
+++ b/osm-to-route-snapper/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use geo::{
     line_measures::LengthMeasurable, BooleanOps, Contains, Coord, Haversine, Intersects,
     LineString, MultiLineString, MultiPolygon,
@@ -35,39 +35,39 @@ pub fn convert_osm(
     Ok(map)
 }
 
-fn get_boundary(
-    boundary_gj: Option<String>,
-) -> Result<Option<MultiPolygon>> {
-    let mut boundary = None;
-    if let Some(gj_string) = boundary_gj {
-        info!("Parsing boundary");
-        let gj: geojson::GeoJson = gj_string.parse()?;
-        let geom = match &gj {
-            geojson::GeoJson::Geometry(g) => Some(&g.value),
-            geojson::GeoJson::Feature(f) => f.geometry.as_ref().map(|g| &g.value),
-            geojson::GeoJson::FeatureCollection(fc) => {
-                if fc.features.len() > 1 { 
-                    return Err(anyhow::anyhow!( 
-                        "Expected exactly one feature in FeatureCollection, found {}", 
-                        fc.features.len() 
-                    )); 
-                }
+fn get_boundary(boundary_gj: Option<String>) -> Result<Option<MultiPolygon>> {
+    let Some(gj_string) = boundary_gj else {
+        return Ok(None);
+    };
 
-                fc.features.iter().find_map(|f| f.geometry.as_ref().map(|g| &g.value))
+    info!("Parsing boundary");
+    let gj: geojson::GeoJson = gj_string.parse()?;
+    let Some(geom) = (match gj {
+        geojson::GeoJson::Geometry(g) => Some(g.value),
+        geojson::GeoJson::Feature(f) => f.geometry.map(|g| g.value),
+        geojson::GeoJson::FeatureCollection(fc) => {
+            if fc.features.len() > 1 {
+                bail!(
+                    "Expected exactly one feature in FeatureCollection, found {}",
+                    fc.features.len()
+                );
             }
-        };
 
-        let geom = geom.ok_or_else(|| anyhow::anyhow!("No geometry found"))?;
+            fc.features
+                .into_iter()
+                .next()
+                .and_then(|f| f.geometry.map(|g| g.value))
+        }
+    }) else {
+        bail!("No geometry found");
+    };
 
-        let boundary_geo: MultiPolygon = match geom {
-            geojson::Value::Polygon(_) => MultiPolygon(vec![geom.try_into()?]),
-            geojson::Value::MultiPolygon(_) => geom.try_into()?,
-            _ => return Err(anyhow::anyhow!("Expected Polygon or MultiPolygon geometry")),
-        };
-
-        boundary = Some(boundary_geo);
-    }
-    Ok(boundary)
+    let boundary_geo: MultiPolygon = match geom {
+        geojson::Value::Polygon(_) => MultiPolygon(vec![geom.try_into()?]),
+        geojson::Value::MultiPolygon(_) => geom.try_into()?,
+        _ => bail!("Expected Polygon or MultiPolygon geometry"),
+    };
+    Ok(Some(boundary_geo))
 }
 
 struct Way {

--- a/osm-to-route-snapper/src/lib.rs
+++ b/osm-to-route-snapper/src/lib.rs
@@ -17,6 +17,8 @@ pub fn convert_osm(
     boundary_gj: Option<String>,
     road_names: bool,
 ) -> Result<RouteSnapperMap> {
+    let boundary = get_boundary(boundary_gj)?;
+
     info!("Scraping OSM data");
     let (nodes, ways) = scrape_elements(&input_bytes, road_names)?;
     info!(
@@ -25,25 +27,47 @@ pub fn convert_osm(
         ways.len(),
     );
 
-    let mut boundary = None;
-    if let Some(gj_string) = boundary_gj {
-        let gj: geojson::Feature = gj_string.parse()?;
-        let boundary_geo: MultiPolygon = if matches!(
-            gj.geometry.as_ref().unwrap().value,
-            geojson::Value::Polygon(_)
-        ) {
-            MultiPolygon(vec![gj.try_into()?])
-        } else {
-            gj.try_into()?
-        };
-        boundary = Some(boundary_geo);
-    }
-
     let mut map = split_edges(nodes, ways, boundary.as_ref());
     if let Some(boundary) = boundary {
+        info!("Clipping boundary");
         clip(&mut map, boundary);
     }
     Ok(map)
+}
+
+fn get_boundary(
+    boundary_gj: Option<String>,
+) -> Result<Option<MultiPolygon>> {
+    let mut boundary = None;
+    if let Some(gj_string) = boundary_gj {
+        info!("Parsing boundary");
+        let gj: geojson::GeoJson = gj_string.parse()?;
+        let geom = match &gj {
+            geojson::GeoJson::Geometry(g) => Some(&g.value),
+            geojson::GeoJson::Feature(f) => f.geometry.as_ref().map(|g| &g.value),
+            geojson::GeoJson::FeatureCollection(fc) => {
+                if fc.features.len() > 1 { 
+                    return Err(anyhow::anyhow!( 
+                        "Expected exactly one feature in FeatureCollection, found {}", 
+                        fc.features.len() 
+                    )); 
+                }
+
+                fc.features.iter().find_map(|f| f.geometry.as_ref().map(|g| &g.value))
+            }
+        };
+
+        let geom = geom.ok_or_else(|| anyhow::anyhow!("No geometry found"))?;
+
+        let boundary_geo: MultiPolygon = match geom {
+            geojson::Value::Polygon(_) => MultiPolygon(vec![geom.try_into()?]),
+            geojson::Value::MultiPolygon(_) => geom.try_into()?,
+            _ => return Err(anyhow::anyhow!("Expected Polygon or MultiPolygon geometry")),
+        };
+
+        boundary = Some(boundary_geo);
+    }
+    Ok(boundary)
 }
 
 struct Way {

--- a/osm-to-route-snapper/src/main.rs
+++ b/osm-to-route-snapper/src/main.rs
@@ -7,7 +7,7 @@ use osm_to_route_snapper::convert_osm;
 #[derive(Parser)]
 struct Args {
     /// Path to a .osm.pbf or .xml file to convert
-    #[arg(long)]
+    #[arg(short, long)]
     input: String,
 
     /// Path to GeoJSON file with the boundary to clip the input to
@@ -15,11 +15,11 @@ struct Args {
     boundary: Option<String>,
 
     /// Output file to write
-    #[arg(long, default_value = "snap.bin")]
+    #[arg(short, long, default_value = "snap.bin")]
     output: String,
 
     /// Omit road names from the output, saving some space.
-    #[clap(long)]
+    #[clap(short, long)]
     no_road_names: bool,
 }
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -12,16 +12,46 @@ A common use case is routing along a street network. You can create an example
 file from OpenStreetMap data. The easiest way to do this for smaller areas is
 [in your web browser](https://dabreegster.github.io/route_snapper/import.html).
 
-For larger areas, you need an `.osm.xml` or `.osm.pbf` file, and optionally a
-GeoJSON file with one polygon or multipolygon representing the boundary of your
-area. You'll need to [install Rust](https://www.rust-lang.org/tools/install) to
-run this:
+For larger areas, you need an `.osm.xml` or `.osm.pbf` file. 
+ - For medium-sized areas you can use the
+   [OpenStreetMap.org exporter](https://www.openstreetmap.org/export)
+ - For larger areas you can download daily-updated national and regional files
+   from [geofabrik.de](https://download.geofabrik.de/).
+ - The files do not need to be modified prior to loading into this tool, but 
+   you can optionally use tools like [osmium](https://osmcode.org/osmium-tool/) 
+   to further filter which roads you want to be included in the routing file.
+
+You can optionally specify a GeoJSON file with one Polygon or MultiPolygon 
+representing the boundary of your area. The (multi)polygon can be specified as 
+a standalone Geometry, a standalone Feature, or a GeometryCollection containing 
+a single Feature. You can use a tool like [geojson.io](https://geojson.io/) to 
+draw and export a file. 
+
+You'll need to [install Rust](https://www.rust-lang.org/tools/install) to
+run this. You can also run it inside Docker using one of the 
+[official rust images](https://hub.docker.com/_/rust), e.g. `rust:alpine`.
+
+```sh
+cd osm-to-route-snapper
+cargo run --release -- -i path_to_osm.xml [-b path_to_boundary.geojson]
+```
+
+To run the tool multiple times, you can build it, then execute it directly:
+
+```sh
+cargo build --release
+./target/release/osm-to-route-snapper --help
+```
+
+Full command arguments:
 
 ```
-cd osm-to-route-snapper
-cargo run --release \
-  -i path_to_osm.xml \
-  [-b path_to_boundary.geojson]
+Options:
+  -i, --input <INPUT>        Path to a .osm.pbf or .xml file to convert
+  -b, --boundary <BOUNDARY>  Path to GeoJSON file with the boundary to clip the input to
+  -o, --output <OUTPUT>      Output file to write [default: snap.bin]
+  -n, --no-road-names        Omit road names from the output, saving some space
+  -h, --help                 Print help
 ```
 
 ### From custom GeoJSON files
@@ -31,9 +61,25 @@ network, you can turn this into a graph too. Try first [in your web
 browser](https://dabreegster.github.io/route_snapper/import.html) using the
 button at the top. For larger areas, install Rust and then:
 
-```
+```sh
 cd geojson-to-route-snapper
-cargo run --release -- --input path_to_network.geojson
+cargo run --release -- -i path_to_network.geojson
+```
+
+To run the tool multiple times, you can build it, then execute it directly:
+
+```sh
+cargo build --release
+./target/release/geojson-to-route-snapper --help
+```
+
+Full command arguments:
+
+```
+Options:
+  -i, --input <INPUT>    Path to a .geojson file to convert
+  -o, --output <OUTPUT>  Output file to write [default: snap.bin]
+  -h, --help             Print help
 ```
 
 For routing to work, the LineStrings must share points with other LineStrings.

--- a/user_guide.md
+++ b/user_guide.md
@@ -23,9 +23,9 @@ For larger areas, you need an `.osm.xml` or `.osm.pbf` file.
 
 You can optionally specify a GeoJSON file with one Polygon or MultiPolygon 
 representing the boundary of your area. The (multi)polygon can be specified as 
-a standalone Geometry, a standalone Feature, or a GeometryCollection containing 
+a standalone Geometry, a standalone Feature, or a FeatureCollection containing
 a single Feature. You can use a tool like [geojson.io](https://geojson.io/) to 
-draw and export a file. 
+draw and export a boundary.
 
 You'll need to [install Rust](https://www.rust-lang.org/tools/install) to
 run this. You can also run it inside Docker using one of the 


### PR DESCRIPTION
Closes #64 

 - Configures all command arguments to support short flags (as implied in the user guide)
 - Updates GeoJSON file for boundaries to allow for Feature, Geometry, or FeatureCollection format
   - Note - I am not very familiar with rust. I was able to get this change working, but feel free to make edits if needed. I did test with one clipping file for each of the 3 formats, attached here for testing: [bounds-examples.zip](https://github.com/user-attachments/files/24420913/bounds-examples.zip). 
   - I also relocated the GeoJSON parsing to happen before the osm file gets scraped, so you get error messages sooner if the geojson file is malformed. Ideally the clipping might be applied to the osm file itself to save time in the scraping and splitting process, but that seemed like a more substantial change and I'm not sufficiently familiar with the tooling to take that on. 
 - Updates user guide to include:
   -  Info reflecting above changes
   -  Add more detail on available command arguments
   - More detail on where to get osm.pbf files and modifications
   - Fixes errors in build commands
   - Adds info on using Docker for builds